### PR TITLE
Fix logical error in jActivityManager

### DIFF
--- a/utils/src/main/java/com/jude/utils/JActivityManager.java
+++ b/utils/src/main/java/com/jude/utils/JActivityManager.java
@@ -83,20 +83,31 @@ public class JActivityManager {
     }
 
     /**
-     * 退出指定名字的activity
+     * close a specific activity by its complete name.
+     *
+     * @param name For example: com.jude.utils.Activity_B
      */
     public void closeActivityByName(String name) {
+        int index = activityStack.size() - 1;
+
         while (true) {
-            Activity activity = currentActivity();
+            Activity activity = activityStack.get(index);
+
             if (null == activity) {
                 break;
             }
 
-            String activityName = activity.getComponentName().getClassName().toString();
-            if (TextUtils.equals(name, activityName)) {
+            String activityName = activity.getComponentName().getClassName();
+            if (!TextUtils.equals(name, activityName)) {
+                index--;
+                if (index < 0) {//avoid index out of bound.
+                    break;
+                }
                 continue;
             }
             popActivity(activity);
+            closeActivity(activity);
+            break;
         }
     }
 


### PR DESCRIPTION
关于jActivityManager中closeActivityByName()方法：
你原来代码为：

``` java
public void closeActivityByName(String name) {
        while (true) {
            Activity activity = currentActivity();//获得栈顶活动
            if (null == activity) {
                break;
            }
            //获得栈顶活动名字
            String activityName = activity.getComponentName().getClassName().toString();
            //如果二者相等，continue回到while语句头部继续执行，下面的popActivity(activity)永远不会执行
            //所以，这应该属于逻辑错误，死循环
            if (TextUtils.equals(name, activityName)) {
                continue;
            }
            popActivity(activity);
        }
    }
```
